### PR TITLE
Add UiHelper module

### DIFF
--- a/src/aind_behavior_experiment_launcher/launcher/_base.py
+++ b/src/aind_behavior_experiment_launcher/launcher/_base.py
@@ -74,7 +74,7 @@ class BaseLauncher(ABC, Generic[TRig, TSession, TTaskLogic]):
         self._logger = _logger
 
         # Solve UI helper
-        self._ui_helper = ui_helper.UIHelper()
+        self._ui_helper = ui_helper.DefaultUIHelper()
 
         # Solve CLI arguments
         self._cli_args: _CliArgs = self._cli_wrapper()

--- a/src/aind_behavior_experiment_launcher/launcher/git_manager.py
+++ b/src/aind_behavior_experiment_launcher/launcher/git_manager.py
@@ -4,7 +4,7 @@ from typing import List, Self
 
 from git import Repo
 
-from aind_behavior_experiment_launcher.ui_helper import UIHelper
+from aind_behavior_experiment_launcher.ui_helper import UiHelper
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +50,7 @@ class GitRepository(Repo):
         _ = [GitRepository(str(sub.abspath)).full_reset() for sub in self.submodules]
         return self
 
-    def try_prompt_full_reset(self, ui_helper: UIHelper, force_reset: bool = False) -> Self:
+    def try_prompt_full_reset(self, ui_helper: UiHelper, force_reset: bool = False) -> Self:
         if force_reset:
             self.full_reset()
             return self

--- a/src/aind_behavior_experiment_launcher/ui_helper/__init__.py
+++ b/src/aind_behavior_experiment_launcher/ui_helper/__init__.py
@@ -1,0 +1,9 @@
+from ._base import UiHelper, UiHelperBase
+from .default import DefaultUIHelper, prompt_field_from_input
+
+__all__ = [
+    "UiHelperBase",
+    "DefaultUIHelper",
+    "prompt_field_from_input",
+    "UiHelper",
+]

--- a/src/aind_behavior_experiment_launcher/ui_helper/_base.py
+++ b/src/aind_behavior_experiment_launcher/ui_helper/_base.py
@@ -1,0 +1,31 @@
+import abc
+import logging
+from typing import Any, Callable, List, Optional, TypeVar
+
+logger = logging.getLogger(__name__)
+
+_PrintFunc = Callable[[str], Any]
+_DEFAULT_PRINT_FUNC: _PrintFunc = print
+T = TypeVar("T", bound=Any)
+
+
+class UiHelperBase(abc.ABC):
+    _print: _PrintFunc
+
+    def __init__(self, *args, print_func: Optional[_PrintFunc] = None, **kwargs):
+        self._print = print_func if print_func is not None else _DEFAULT_PRINT_FUNC
+
+    def print(self, message: str) -> Any:
+        return self._print(message)
+
+    @abc.abstractmethod
+    def prompt_pick_from_list(self, value: List[str], prompt: str, **kwargs) -> Optional[str]: ...
+
+    @abc.abstractmethod
+    def prompt_yes_no_question(self, prompt: str) -> bool: ...
+
+    @abc.abstractmethod
+    def prompt_text(self, prompt: str) -> str: ...
+
+
+UiHelper = UiHelperBase

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,5 +1,6 @@
 import subprocess
 import unittest
+import unittest.mock
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -62,7 +63,7 @@ class TestBonsaiApp(unittest.TestCase):
         self.app._result = mock_result
         self.assertEqual(self.app.result, mock_result)
 
-    @patch("aind_behavior_experiment_launcher.apps.bonsai.UIHelper.prompt_yes_no_question", return_value=True)
+    @patch("aind_behavior_experiment_launcher.apps.bonsai.DefaultUIHelper.prompt_yes_no_question", return_value=True)
     def test_output_from_result(self, mock_prompt):
         mock_result = MagicMock(spec=subprocess.CompletedProcess)
         mock_result.stdout = "output"
@@ -77,10 +78,10 @@ class TestBonsaiApp(unittest.TestCase):
             self.assertEqual(self.app.output_from_result(allow_stderr=True), self.app)
 
     @patch(
-        "aind_behavior_experiment_launcher.apps.bonsai.UIHelper.prompt_pick_file_from_list",
+        "aind_behavior_experiment_launcher.apps.bonsai.DefaultUIHelper.prompt_pick_from_list",
         return_value="picked_layout.bonsai.layout",
     )
-    def test_prompt_visualizer_layout_input(self, mock_prompt_pick_file_from_list):
+    def test_prompt_visualizer_layout_input(self, mock_ui_helper):
         with patch("glob.glob", return_value=["layout1.bonsai.layout", "layout2.bonsai.layout"]):
             layout = self.app.prompt_visualizer_layout_input()
             self.assertEqual(layout, "picked_layout.bonsai.layout")

--- a/tests/test_ui_helpers.py
+++ b/tests/test_ui_helpers.py
@@ -1,12 +1,12 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from aind_behavior_experiment_launcher.ui_helper import UIHelper
+from aind_behavior_experiment_launcher.ui_helper import DefaultUIHelper
 
 
-class TestUIHelper(unittest.TestCase):
+class TestDefaultUiHelper(unittest.TestCase):
     def setUp(self):
-        self.ui_helper = UIHelper(print_func=MagicMock())
+        self.ui_helper = DefaultUIHelper(print_func=MagicMock())
 
     @patch("builtins.input", side_effect=["1"])
     def test_prompt_pick_file_from_list(self, mock_input):
@@ -44,7 +44,7 @@ class TestUIHelper(unittest.TestCase):
 
     @patch("builtins.input", side_effect=["Some notes"])
     def test_prompt_get_notes(self, mock_input):
-        result = self.ui_helper.prompt_get_notes()
+        result = self.ui_helper.prompt_text("")
         self.assertEqual(result, "Some notes")
 
 


### PR DESCRIPTION
This PR formalizes the concept of a UiHelper generic class. For now it will contain simple methods for UX, mainly prompts. The idea is that in the future, it can be used to flexibly be able to recruit different UI builders to perform the same functionality. For instance, `prompt_text` could be provided by a simple `input` stdlib call or by a complex TK-based GUI.