### PR TITLE
Add LocalDetachedExecutor

### DIFF
--- a/src/clabe/apps/__init__.py
+++ b/src/clabe/apps/__init__.py
@@ -11,6 +11,7 @@ from ._base import (
 )
 from ._bonsai import AindBehaviorServicesBonsaiApp, BonsaiApp
 from ._curriculum import CurriculumApp, CurriculumSettings, CurriculumSuggestion
+from ._executors import LocalDetachedExecutor
 from ._python_script import PythonScriptApp
 
 __all__ = [
@@ -30,4 +31,5 @@ __all__ = [
     "PythonScriptApp",
     "ExecutableApp",
     "StdCommand",
+    "LocalDetachedExecutor",
 ]

--- a/src/clabe/apps/_executors.py
+++ b/src/clabe/apps/_executors.py
@@ -189,6 +189,66 @@ class AsyncLocalExecutor(AsyncExecutor):
         return command_result
 
 
+class LocalDetachedExecutor(Executor):
+    """
+    Fire-and-forget executor that spawns a subprocess and returns immediately.
+
+    Launches the command via ``subprocess.Popen`` without waiting for it to
+    finish.  stdout and stderr are redirected to ``DEVNULL`` so that no pipe
+    handles are left open.  The returned ``CommandResult`` is a placeholder
+    with ``exit_code=0`` and no captured output; callers must not rely on it
+    to reflect the actual process outcome.
+
+    Attributes:
+        cwd: Working directory for command execution
+        env: Environment variables for the subprocess
+
+    Example:
+        ```python
+        executor = LocalDetachedExecutor()
+        cmd = Command(cmd=["bonsai", "workflow.bonsai"], output_parser=identity_parser)
+        _ = executor.run(cmd)  # returns immediately; Bonsai keeps running
+        ```
+    """
+
+    def __init__(self, cwd: os.PathLike | None = None, env: dict[str, str] | None = None) -> None:
+        """Initialize the detached executor.
+
+        Args:
+            cwd: Working directory for command execution
+            env: Environment variables for the subprocess
+        """
+        self.cwd = cwd or os.getcwd()
+        self.env = env
+
+    def run(self, command: Command[Any]) -> CommandResult:
+        """Spawn the command and return immediately without waiting.
+
+        Args:
+            command: The command to execute (as a list of strings)
+
+        Returns:
+            A placeholder ``CommandResult`` with ``exit_code=0`` and no output.
+            The actual process exit code is never captured.
+
+        Example:
+            ```python
+            executor = LocalDetachedExecutor()
+            cmd = Command(cmd=["bonsai", "workflow.bonsai"], output_parser=identity_parser)
+            result = executor.run(cmd)  # fire-and-forget
+            ```
+        """
+        subprocess.Popen(
+            command.cmd,
+            cwd=self.cwd,
+            env=self.env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            shell=False,
+        )
+        return CommandResult(stdout=None, stderr=None, exit_code=0)
+
+
 class _DefaultExecutorMixin:
     """
     Mixin providing default executor implementations for ExecutableApp classes.

--- a/tests/apps/test_app.py
+++ b/tests/apps/test_app.py
@@ -12,6 +12,7 @@ from clabe.apps import (
     CommandError,
     CommandResult,
     Executor,
+    LocalDetachedExecutor,
     PythonScriptApp,
     identity_parser,
 )
@@ -263,6 +264,123 @@ class TestAsyncLocalExecutor:
         assert all(r.ok for r in results)
         assert "cmd1" in (results[0].stdout or "")
         assert "cmd2" in (results[1].stdout or "")
+
+
+# ============================================================================
+# LocalDetachedExecutor Tests
+# ============================================================================
+
+
+class TestLocalDetachedExecutor:
+    """Tests for LocalDetachedExecutor (fire-and-forget executor)."""
+
+    @patch("subprocess.Popen")
+    def test_returns_placeholder_result_immediately(self, mock_popen):
+        """run() returns exit_code=0 with no stdout/stderr without waiting."""
+        executor = LocalDetachedExecutor()
+        cmd = Command[CommandResult](cmd=["sleep", "999"], output_parser=identity_parser)
+
+        result = executor.run(cmd)
+
+        assert result.exit_code == 0
+        assert result.stdout is None
+        assert result.stderr is None
+        assert result.ok is True
+
+    @patch("subprocess.Popen")
+    def test_spawns_process_without_waiting(self, mock_popen):
+        """Popen is called once and communicate/wait are never called."""
+        executor = LocalDetachedExecutor()
+        cmd = Command[CommandResult](cmd=["sleep", "999"], output_parser=identity_parser)
+
+        executor.run(cmd)
+
+        mock_popen.assert_called_once()
+        mock_popen.return_value.wait.assert_not_called()
+        mock_popen.return_value.communicate.assert_not_called()
+
+    @patch("subprocess.Popen")
+    def test_passes_command_args_to_popen(self, mock_popen):
+        """The exact command list is forwarded to Popen."""
+        executor = LocalDetachedExecutor()
+        expected_cmd = ["python", "-c", "print('hello')"]
+        cmd = Command[CommandResult](cmd=expected_cmd, output_parser=identity_parser)
+
+        executor.run(cmd)
+
+        call_args = mock_popen.call_args
+        assert call_args[0][0] == expected_cmd
+
+    @patch("subprocess.Popen")
+    def test_stdout_stderr_redirected_to_devnull(self, mock_popen):
+        """stdout and stderr are DEVNULL to avoid unclosed pipe handles."""
+        import subprocess as sp
+
+        executor = LocalDetachedExecutor()
+        cmd = Command[CommandResult](cmd=["echo", "hi"], output_parser=identity_parser)
+
+        executor.run(cmd)
+
+        call_kwargs = mock_popen.call_args[1]
+        assert call_kwargs["stdout"] == sp.DEVNULL
+        assert call_kwargs["stderr"] == sp.DEVNULL
+
+    @patch("subprocess.Popen")
+    def test_shell_is_false(self, mock_popen):
+        """shell=False is enforced to prevent shell injection."""
+        executor = LocalDetachedExecutor()
+        cmd = Command[CommandResult](cmd=["echo", "hi"], output_parser=identity_parser)
+
+        executor.run(cmd)
+
+        call_kwargs = mock_popen.call_args[1]
+        assert call_kwargs["shell"] is False
+
+    @patch("subprocess.Popen")
+    def test_uses_provided_cwd(self, mock_popen, tmp_path: Path):
+        """Custom cwd is passed through to Popen."""
+        executor = LocalDetachedExecutor(cwd=tmp_path)
+        cmd = Command[CommandResult](cmd=["echo", "hi"], output_parser=identity_parser)
+
+        executor.run(cmd)
+
+        call_kwargs = mock_popen.call_args[1]
+        assert call_kwargs["cwd"] == tmp_path
+
+    @patch("subprocess.Popen")
+    def test_defaults_cwd_to_getcwd(self, mock_popen):
+        """When cwd is omitted, cwd defaults to os.getcwd()."""
+        import os
+
+        executor = LocalDetachedExecutor()
+        assert executor.cwd == os.getcwd()
+
+    @patch("subprocess.Popen")
+    def test_uses_provided_env(self, mock_popen):
+        """Custom env dict is passed through to Popen."""
+        custom_env = {"MY_VAR": "my_value"}
+        executor = LocalDetachedExecutor(env=custom_env)
+        cmd = Command[CommandResult](cmd=["echo", "hi"], output_parser=identity_parser)
+
+        executor.run(cmd)
+
+        call_kwargs = mock_popen.call_args[1]
+        assert call_kwargs["env"] == custom_env
+
+    @patch("subprocess.Popen")
+    def test_satisfies_executor_protocol(self, mock_popen):
+        """LocalDetachedExecutor satisfies the Executor protocol."""
+        executor = LocalDetachedExecutor()
+        assert isinstance(executor, Executor)
+
+    @patch("subprocess.Popen")
+    def test_placeholder_result_does_not_raise_on_check_returncode(self, mock_popen):
+        """The placeholder CommandResult does not raise when check_returncode() is called."""
+        executor = LocalDetachedExecutor()
+        cmd = Command[CommandResult](cmd=["echo", "hi"], output_parser=identity_parser)
+
+        result = executor.run(cmd)
+        result.check_returncode()  # must not raise
 
 
 # ============================================================================


### PR DESCRIPTION
Adds `LocalDetachedExecutor`, a fire-and-forget `Executor` implementation that spawns a subprocess via `subprocess.Popen` and returns immediately without waiting for it to complete.

**Design:**
- Implements the existing `Executor` protocol — no new interface required
- `stdout`/`stderr` redirected to `DEVNULL` (no dangling pipe handles)
- `shell=False` enforced
- Returns a placeholder `CommandResult(stdout=None, stderr=None, exit_code=0)` immediately; callers must not rely on it to reflect actual process outcome
- Exported from `clabe.apps`

**Usage:**
```python
from clabe.apps import LocalDetachedExecutor

executor = LocalDetachedExecutor()
executor.run(app.command)  # spawns process, returns immediately
```