### PR TITLE
Implement read-only tabular viewer

### DIFF
--- a/examples/behavior_launcher.py
+++ b/examples/behavior_launcher.py
@@ -22,7 +22,15 @@ from clabe.cache_manager import CacheManager
 from clabe.launcher import Launcher, LauncherCliArgs, experiment
 from clabe.pickers import DefaultBehaviorPicker, DefaultBehaviorPickerSettings
 from clabe.runnable import runnable
-from clabe.ui import AcknowledgeRequest, ConfirmRequest, FieldRequest, FormRequest, MessageLevel, notify
+from clabe.ui import (
+    AcknowledgeRequest,
+    ConfirmRequest,
+    FieldRequest,
+    FormRequest,
+    MessageLevel,
+    ReadOnlyTable,
+    notify,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -102,6 +110,22 @@ async def demo_experiment(launcher: Launcher) -> None:
         notify("Form cancelled — using defaults.", MessageLevel.WARNING)
         config = SessionConfig()
 
+    # --- ReadOnlyTable demo (from_object): review the filled config ---------
+    # Renders the model as a read-only "Parameter | Value" table with OK/Cancel.
+    confirmed = launcher.frontend.prompt_read_only_table(
+        ReadOnlyTable.from_object(
+            config,
+            title="Confirm Session Configuration",
+            prompt="Are these settings correct?",
+            confirm_label="Looks good",
+            cancel_label="Go back",
+        )
+    )
+    if not confirmed:
+        notify("Configuration not confirmed — using defaults.", MessageLevel.WARNING)
+        config = SessionConfig()
+    # ----------------------------------------------------------------------
+
     updated_type = launcher.frontend.prompt_field(
         FieldRequest(
             model=SessionConfig,
@@ -151,6 +175,21 @@ async def demo_experiment(launcher: Launcher) -> None:
 
     app_1 = PythonScriptApp(script=fmt("Behavior"))
     app_2 = PythonScriptApp(script=fmt("Physiology"))
+
+    # --- ReadOnlyTable demo (from_records): review the app run plan ---------
+    # A general grid built from a list of dicts; columns are inferred from keys.
+    if not launcher.frontend.prompt_read_only_table(
+        ReadOnlyTable.from_records(
+            [
+                {"App": "Behavior", "Timeout (s)": 2, "Blocking": False},
+                {"App": "Physiology", "Timeout (s)": 2, "Blocking": False},
+            ],
+            title="App Run Plan",
+            prompt="Run these apps?",
+        )
+    ):
+        notify("App run cancelled by user.", MessageLevel.WARNING)
+    # ----------------------------------------------------------------------
 
     notify("Running the behavior and physiology apps…", MessageLevel.INFO)
     app_1_result, app_2_result = await asyncio.gather(

--- a/src/clabe/ui/__init__.py
+++ b/src/clabe/ui/__init__.py
@@ -11,6 +11,7 @@ from ._requests import (
     FormRequest,
     NumberRequest,
     PickRequest,
+    ReadOnlyTable,
     TextRequest,
     Validator,
 )
@@ -70,6 +71,7 @@ __all__ = [
     "MessageLevel",
     "Choice",
     "PickRequest",
+    "ReadOnlyTable",
     "ConfirmRequest",
     "TextRequest",
     "AutoCompleteRequest",

--- a/src/clabe/ui/_frontend.py
+++ b/src/clabe/ui/_frontend.py
@@ -14,6 +14,7 @@ from ._requests import (
     FormRequest,
     NumberRequest,
     PickRequest,
+    ReadOnlyTable,
     TextRequest,
     Validator,
 )
@@ -99,6 +100,10 @@ class Frontend(Protocol):
 
     def prompt_form(self, request: FormRequest) -> Optional[object]:
         """Prompt the user to fill in a Pydantic model form; returns the validated instance or None."""
+        ...
+
+    def prompt_read_only_table(self, request: ReadOnlyTable) -> bool:
+        """Display read-only tabular data and collect a yes/no answer; returns the answer."""
         ...
 
     def prompt_field(self, request: FieldRequest) -> Any:
@@ -273,6 +278,21 @@ class FrontendBase(abc.ABC):
             NotImplementedError: This frontend does not support form prompts.
         """
         raise NotImplementedError(f"{type(self).__name__} does not support form prompts.")
+
+    def prompt_read_only_table(self, request: ReadOnlyTable) -> bool:
+        """
+        Displays read-only tabular data and collects a yes/no answer.
+
+        Args:
+            request: The declarative read-only-table request.
+
+        Returns:
+            bool: ``True`` if the user confirmed, ``False`` otherwise.
+
+        Raises:
+            NotImplementedError: This frontend does not support table prompts.
+        """
+        raise NotImplementedError(f"{type(self).__name__} does not support read-only-table prompts.")
 
     def prompt_acknowledge(self, request: AcknowledgeRequest) -> None:
         """

--- a/src/clabe/ui/_requests.py
+++ b/src/clabe/ui/_requests.py
@@ -1,5 +1,7 @@
 import dataclasses
-from typing import Callable, List, Optional, Sequence, Union
+from typing import Any, Callable, List, Mapping, Optional, Sequence, Union
+
+from pydantic import BaseModel
 
 #: A validator takes a candidate answer and returns ``None`` when the value is
 #: acceptable, or an error message (to surface to the user) when it is not.
@@ -203,3 +205,89 @@ class FieldRequest:
     model: type
     field_name: str
     initial: Optional[object] = None
+
+
+@dataclasses.dataclass
+class ReadOnlyTable:
+    """
+    A declarative request to display tabular data read-only and collect a yes/no.
+
+    The table is never editable; it exists to show the user a set of values and
+    gather a single confirmation. The affirmative button returns ``True`` and the
+    negative button returns ``False`` (as does dismissing the dialog).
+
+    Prefer the constructors over populating ``columns`` and ``rows`` by hand:
+
+    * :meth:`from_records` — a sequence of mappings, one row each; columns are
+      inferred from the keys (first-seen order) unless given explicitly.
+    * :meth:`from_object` — a Pydantic model instance or a plain mapping rendered
+      as a two-column ``Parameter | Value`` table, one row per field/key.
+
+    Attributes:
+        columns: Column headers, left to right.
+        rows: Row values; each inner sequence aligns positionally to ``columns``.
+        title: Optional title shown above the table.
+        prompt: Optional question shown near the buttons (e.g. "Is this correct?").
+        confirm_label: Label on the affirmative button. Defaults to ``"OK"``.
+        cancel_label: Label on the negative button. Defaults to ``"Cancel"``.
+        field: Logical field name used in the persisted transcript.
+    """
+
+    columns: Sequence[str]
+    rows: Sequence[Sequence[Any]]
+    title: Optional[str] = None
+    prompt: Optional[str] = None
+    confirm_label: str = "OK"
+    cancel_label: str = "Cancel"
+    field: Optional[str] = None
+
+    @classmethod
+    def from_records(
+        cls,
+        records: Sequence[Mapping[str, Any]],
+        *,
+        columns: Optional[Sequence[str]] = None,
+        **kwargs: Any,
+    ) -> "ReadOnlyTable":
+        """
+        Build a table from a sequence of mappings (one row per mapping).
+
+        When ``columns`` is omitted it is inferred from the union of the record
+        keys, preserving first-seen order. Keys absent from a given record render
+        as empty cells.
+        """
+        records = list(records)
+        if columns is None:
+            seen: dict = {}
+            for record in records:
+                for key in record:
+                    seen.setdefault(key, None)
+            columns = list(seen)
+        else:
+            columns = list(columns)
+        rows = [[record.get(column, "") for column in columns] for record in records]
+        return cls(columns=columns, rows=rows, **kwargs)
+
+    @classmethod
+    def from_object(
+        cls,
+        obj: Union[Mapping[str, Any], BaseModel],
+        *,
+        key_header: str = "Parameter",
+        value_header: str = "Value",
+        **kwargs: Any,
+    ) -> "ReadOnlyTable":
+        """
+        Build a two-column ``Parameter | Value`` table from a model or mapping.
+
+        Accepts a Pydantic model instance or a plain mapping; each field/key
+        becomes one row.
+        """
+        if isinstance(obj, BaseModel):
+            data = obj.model_dump()
+        elif isinstance(obj, Mapping):
+            data = dict(obj)
+        else:
+            raise TypeError(f"from_object expects a Pydantic model or mapping, got {type(obj).__name__}.")
+        rows = [[str(key), value] for key, value in data.items()]
+        return cls(columns=[key_header, value_header], rows=rows, **kwargs)

--- a/src/clabe/ui/_textual.py
+++ b/src/clabe/ui/_textual.py
@@ -19,8 +19,16 @@ from .. import __version__
 from ..logging_helper import _TRANSCRIPT_LOGGER_NAME
 from ._frontend import FrontendBase
 from ._messages import MessageLevel
-from ._requests import AcknowledgeRequest, AutoCompleteRequest, ConfirmRequest, FormRequest, PickRequest, TextRequest
-from ._textual_form import _AcknowledgeScreen, _FormScreen
+from ._requests import (
+    AcknowledgeRequest,
+    AutoCompleteRequest,
+    ConfirmRequest,
+    FormRequest,
+    PickRequest,
+    ReadOnlyTable,
+    TextRequest,
+)
+from ._textual_form import _AcknowledgeScreen, _FormScreen, _ReadOnlyTableScreen
 
 #: Sentinel pushed back to the caller when a prompt is cancelled (e.g. Ctrl+C).
 _CANCELLED = object()
@@ -316,6 +324,15 @@ class _LauncherApp(App):
 
         await self.push_screen(_AcknowledgeScreen(request), _on_dismiss)
 
+    async def ask_read_only_table(self, request: ReadOnlyTable, reply: "queue.Queue") -> None:
+        """Push a read-only table modal; deliver the bool answer via reply."""
+
+        async def _on_dismiss(result: object) -> None:
+            """Put the table answer (True/False) onto the reply queue."""
+            reply.put(result)
+
+        await self.push_screen(_ReadOnlyTableScreen(request), _on_dismiss)
+
     async def _mount(self, *widgets) -> None:
         """Replace the Input pane contents with the given widgets."""
         box = self.query_one("#clabe-prompt", Vertical)
@@ -590,6 +607,19 @@ class TextualFrontend(FrontendBase):
         if result is not None:
             self._record(request.field or request.model.__name__, str(result))
         return result
+
+    def _ask_read_only_table(self, request: ReadOnlyTable) -> bool:
+        """Push the read-only table modal and block until the user answers."""
+        app = self._ensure()
+        reply: "queue.Queue" = queue.Queue()
+        app.call_from_thread(app.ask_read_only_table, request, reply)
+        return bool(_unwrap(reply.get()))
+
+    def prompt_read_only_table(self, request: ReadOnlyTable) -> bool:
+        """Display read-only tabular data; return True on confirm, False on cancel."""
+        answer = self._ask_read_only_table(request)
+        self._record(request.field or request.title or "read_only_table", answer)
+        return answer
 
     def _ask_acknowledge(self, request: AcknowledgeRequest) -> None:
         """Push the acknowledge modal and block until the user dismisses it."""

--- a/src/clabe/ui/_textual_form.py
+++ b/src/clabe/ui/_textual_form.py
@@ -11,9 +11,9 @@ from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, ScrollableContainer, Vertical
 from textual.screen import ModalScreen
-from textual.widgets import Button, DirectoryTree, Footer, Input, Label, OptionList, Select, Switch
+from textual.widgets import Button, DataTable, DirectoryTree, Footer, Input, Label, OptionList, Select, Switch
 
-from ._requests import AcknowledgeRequest, FormRequest
+from ._requests import AcknowledgeRequest, FormRequest, ReadOnlyTable
 
 
 def _humanize(name: str) -> str:
@@ -158,6 +158,21 @@ _HelpPopup { align: center middle; }
 #help-ok { width: 100%; }
 """
 
+_READ_ONLY_TABLE_CSS = """
+_ReadOnlyTableScreen { align: center middle; }
+#table-outer {
+    width: auto; height: auto;
+    max-width: 90vw; max-height: 90vh;
+    background: $surface; border: round $primary;
+    align-horizontal: center; padding: 1 2;
+}
+#table-title { width: auto; color: $accent; text-style: bold; margin-bottom: 1; }
+#table-prompt { width: auto; margin-bottom: 1; }
+#table-data { width: auto; height: auto; max-width: 86vw; max-height: 78vh; }
+#table-buttons { width: auto; min-width: 100%; height: 3; margin-top: 1; align-horizontal: center; }
+#table-buttons Button { margin: 0 1; }
+"""
+
 _ACKNOWLEDGE_CSS = """
 _AcknowledgeScreen { align: center middle; }
 #ack-box {
@@ -236,6 +251,55 @@ class _AcknowledgeScreen(ModalScreen):
     def action_ok(self) -> None:
         """Dismiss the dialog."""
         self.dismiss()
+
+
+def _cell(value: Any) -> str:
+    """Render a cell value as display text (``None`` becomes an empty cell)."""
+    return "" if value is None else str(value)
+
+
+class _ReadOnlyTableScreen(ModalScreen):
+    """Modal that displays read-only tabular data and collects an OK/Cancel answer."""
+
+    DEFAULT_CSS = _READ_ONLY_TABLE_CSS
+    BINDINGS = [Binding("escape", "cancel", "Cancel")]
+
+    def __init__(self, request: ReadOnlyTable) -> None:
+        """Initialize with the declarative read-only-table request."""
+        super().__init__()
+        self._request = request
+        self._title_text = request.title or "Review"
+
+    def compose(self) -> ComposeResult:
+        """Build the table dialog layout."""
+        with Vertical(id="table-outer"):
+            yield Label(self._title_text, id="table-title")
+            if self._request.prompt:
+                yield Label(self._request.prompt, id="table-prompt")
+            yield DataTable(id="table-data", cursor_type="row", zebra_stripes=True)
+            with Horizontal(id="table-buttons"):
+                yield Button(self._request.cancel_label, id="table-cancel", variant="default")
+                yield Button(self._request.confirm_label, id="table-ok", variant="primary")
+
+    def on_mount(self) -> None:
+        """Populate the table and focus the confirm button."""
+        table = self.query_one("#table-data", DataTable)
+        table.add_columns(*[str(column) for column in self._request.columns])
+        for row in self._request.rows:
+            table.add_row(*[_cell(value) for value in row])
+        self.query_one("#table-ok", Button).focus()
+
+    async def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Dismiss True on the confirm button, False on cancel."""
+        btn_id = event.button.id or ""
+        if btn_id == "table-ok":
+            self.dismiss(True)
+        elif btn_id == "table-cancel":
+            self.dismiss(False)
+
+    def action_cancel(self) -> None:
+        """Dismiss the dialog with a negative answer."""
+        self.dismiss(False)
 
 
 class _FilePickerScreen(ModalScreen):


### PR DESCRIPTION

## Summary

Adds a new declarative UI request, **`ReadOnlyTable`**, for showing the user a read-only table of data and collecting a single yes/no answer ("does this look right?"). It renders as a Textual modal with a non-editable `DataTable` and centered **OK / Cancel** buttons, returning `True` on confirm and `False` on cancel/escape. The dialog auto-sizes to its content (capped at 90% of the terminal) and scrolls the table when it's taller than the screen.

Two ergonomic constructors cover the common shapes:

- `from_records(list[dict])` — a general grid; columns inferred from the keys.
- `from_object(model_or_dict)` — a Pydantic model **or** a plain dict rendered as a two-column **Parameter | Value** table, one row per field.

Wired into the `Frontend` protocol as `prompt_read_only_table(...)`; implemented for the Textual frontend (the console frontend raises `NotImplementedError`, consistent with `FormRequest`). The answer is recorded to the transcript.

## Usage

**Confirm a Pydantic model (Parameter | Value):**

```python
from clabe.ui import ReadOnlyTable

config = launcher.frontend.prompt_form(FormRequest(model=SessionConfig, title="Session Configuration"))

confirmed = launcher.frontend.prompt_read_only_table(
    ReadOnlyTable.from_object(
        config,
        title="Confirm Session Configuration",
        prompt="Are these settings correct?",
        confirm_label="Looks good",
        cancel_label="Go back",
    )
)
if not confirmed:
    config = SessionConfig()  # fall back to defaults
```

**Confirm a plain dict:**

```python
ReadOnlyTable.from_object(
    {"rig": "323", "n_mice": 12, "active": True},
    title="Rig Summary",
    prompt="Proceed?",
)
```

**A multi-row grid from a list of dicts (columns inferred):**

```python
ok = launcher.frontend.prompt_read_only_table(
    ReadOnlyTable.from_records(
        [
            {"App": "Behavior", "Timeout (s)": 2, "Blocking": False},
            {"App": "Physiology", "Timeout (s)": 2, "Blocking": False},
        ],
        title="App Run Plan",
        prompt="Run these apps?",
    )
)
```

**Explicit columns / subset & ordering:**

```python
ReadOnlyTable.from_records(
    records,
    columns=["App", "Blocking"],   # pick + order columns; missing keys render blank
    title="Plan",
)
```

Return value is always a `bool` — branch on it to proceed or abort. See `examples/behavior_launcher.py` for both constructors in a running demo.
